### PR TITLE
Fixed double post request bug

### DIFF
--- a/pages/prediction.tsx
+++ b/pages/prediction.tsx
@@ -19,6 +19,7 @@ import PredictionChart from "../components/prediction/Chart";
 import LoadingOverlay from "../components/prediction/LoadingOverlay";
 import MissingForecastPlaceholder from "../components/MissingForecastPlaceholder";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 export default function Visualization() {
   const router = useRouter();
@@ -41,10 +42,14 @@ export default function Visualization() {
     );
 
   const isFirstRun = Object.keys(router.query).includes("first-run");
-  if (isFirstRun) {
-    router.replace({ query: {} });
-    predictAction();
-  }
+
+  useEffect(() => {
+    if(isFirstRun) {
+      router.replace({query: {}});
+      predictAction();
+    }
+  }, []);
+  
 
   if (!dataset) {
     return <MissingDatasetPlaceholder />;


### PR DESCRIPTION
Fixed a bug where opening the prediction page for the first time would send off two POST requests. This was occurring because router.replace is async and the Visualization component would re-render before the router finished changed the query to not be the first run query.