### PR TITLE
Added unit conversion for forecast horizon

### DIFF
--- a/components/prediction/Builder.tsx
+++ b/components/prediction/Builder.tsx
@@ -104,8 +104,7 @@ const PredictionBuilder = () => {
       <CAccordionItem itemKey={10}>
         <CAccordionHeader>Forecast horizon</CAccordionHeader>
         <CAccordionBody>
-          How far should the model predict into the future? The unit is based on
-          your dataset in <b>{resolution}</b>.
+          How far should the model predict into the future?
           <CInputGroup>
             <CFormInput
               type="number"


### PR DESCRIPTION
Added a dropdown for the unit into the forecast horizon input filed where the unit can be selected in the range from ms to y. Still need to merge the new input validation stuff in and update accordingly, also, I noticed that the minimum value for forecast horizon is 1h (server side)