### PR TITLE
Fixes bug with applying previous model version

### DIFF
--- a/components/history/HistoryListItem.tsx
+++ b/components/history/HistoryListItem.tsx
@@ -6,7 +6,7 @@ import {
 import { useAppSelector } from "../../src/hooks";
 import { useDispatch } from "react-redux";
 import { removeModel, selectModel } from "../../src/store/history";
-import { setModelConfig } from "../../src/store/models";
+import { applyPrevModel } from "../../src/store/models";
 
 export type HistoryListItemProps = {
   index: number;
@@ -60,7 +60,7 @@ export const HistoryListItem = (props: HistoryListItemProps) => {
             color="primary"
             onClick={() => {
               dispatch(selectModel(props.index));
-              dispatch(setModelConfig(model.modelConfig));
+              dispatch(applyPrevModel(model));
               props.onClick();
             }}
           >

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { ModelState, editModelConfig, setModelConfig } from "./models";
+import { ModelState, editModelConfig } from "./models";
 import { apiPrediction } from "./datasets";
 
 export type HistoricModel = {

--- a/src/store/models.ts
+++ b/src/store/models.ts
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import merge from "lodash.merge";
 
 import { forecappApi } from "./forecappApi";
+import { HistoricModel } from "./history";
 
 forecappApi.endpoints.predictionPredictionPost.useMutation;
 
@@ -82,8 +83,8 @@ export const modelSlice = createSlice({
         return merge(state, payload);
       }
     },
-    setModelConfig: (state, action: { payload: ModelState }) => {
-      merge(state, action.payload);
+    applyPrevModel: (state, action: { payload: HistoricModel }) => {
+      state = action.payload.modelConfig;
     },
     editModelConfigJsonView: (_, { payload: { updated_src: newState } }: any) =>
       newState,
@@ -94,7 +95,7 @@ export const modelSlice = createSlice({
   },
 });
 
-export const { editModelConfig, editModelConfigJsonView, removeEvent } =
+export const { editModelConfig, editModelConfigJsonView, removeEvent, applyPrevModel } =
   modelSlice.actions;
 
 export default modelSlice.reducer;


### PR DESCRIPTION
Fixes a small bug where the redux action wasn't being exported, also renamed it to make it more clear what it does.